### PR TITLE
Remove Amplitude analytics

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -120,13 +120,7 @@ const structuredData = {
     <ClientRouter />
 
     <script is:inline src="/toggle-theme.js" async></script>
-    <script src="https://cdn.amplitude.com/script/9fdfb3da776079fb062c77e48dc138de.js"></script>
-    <script>
-      window.amplitude.init('9fdfb3da776079fb062c77e48dc138de', {
-        fetchRemoteConfig: true,
-        autocapture: true
-      });
-    </script>
+
     <script
         src="https://rybbit.umuumi.ipv64.de/api/script.js"
         data-site-id="b5cf8d8d7fc8"

--- a/src/types/amplitude.d.ts
+++ b/src/types/amplitude.d.ts
@@ -1,9 +1,0 @@
-interface Window {
-  amplitude: {
-    add: (plugin: any) => void;
-    init: (apiKey: string, config?: Record<string, unknown>) => void;
-  };
-  sessionReplay: {
-    plugin: (options: { sampleRate: number }) => any;
-  };
-}


### PR DESCRIPTION
## Summary
- Remove Amplitude analytics SDK script tag and `window.amplitude.init()` call from `Layout.astro`
- Delete `src/types/amplitude.d.ts` (TypeScript declarations no longer needed)